### PR TITLE
Add suffix parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Add the following to your `mkdocs.yml`:
 plugins:
   - confluence-publisher:
       confluence_prefix: "MkDocs - "  # Optional: Prefix for page titles in Confluence
+      confluence_suffix: " - MkDocs"  # Optional: Suffix for page titles in Confluence
       space_key: "YOUR_SPACE_KEY"     # Required: Confluence space key
       parent_page_id: 123456          # Required: ID of the parent page in Confluence
 ```

--- a/mkdocs_confluence_publisher/create_pages.py
+++ b/mkdocs_confluence_publisher/create_pages.py
@@ -4,9 +4,9 @@ from .types import MD_to_Page, ConfluencePage
 
 logger = logging.getLogger('mkdocs.plugins.confluence_publisher.create_pages')
 
-def create_pages(confluence, items, prefix, space_key, parent_id, md_to_page: MD_to_Page):
+def create_pages(confluence, items, prefix, suffix, space_key, parent_id, md_to_page: MD_to_Page):
     for item in items:
-        page_title = f"{prefix}{item.title}"
+        page_title = f"{prefix}{item.title}{suffix}"
         logger.debug(f"Processing item: {page_title}")
 
         # Check if the page already exists

--- a/mkdocs_confluence_publisher/create_pages.py
+++ b/mkdocs_confluence_publisher/create_pages.py
@@ -44,6 +44,6 @@ def create_pages(confluence, items, prefix, suffix, space_key, parent_id, md_to_
         # If it's a "Section", recursively create child pages
         if isinstance(item, Section) and item.children:
             logger.debug(f"Processing children of {page_title}")
-            create_pages(confluence, item.children, prefix, space_key, page_id, md_to_page)
+            create_pages(confluence, item.children, prefix, suffix, space_key, page_id, md_to_page)
 
     return md_to_page

--- a/mkdocs_confluence_publisher/plugin.py
+++ b/mkdocs_confluence_publisher/plugin.py
@@ -40,7 +40,7 @@ class ConfluencePublisherPlugin(BasePlugin):
 
     def on_nav(self, nav, config, files):
         prefix = self.config['confluence_prefix']
-        sufix = self.config['confluence_suffix']
+        suffix = self.config['confluence_suffix']
         space_key = self.config['space_key']
         parent_page_id = self.config['parent_page_id']
         self.logger.info(

--- a/mkdocs_confluence_publisher/plugin.py
+++ b/mkdocs_confluence_publisher/plugin.py
@@ -16,6 +16,7 @@ from .types import MD_to_Page
 class ConfluencePublisherPlugin(BasePlugin):
     config_scheme = (
         ('confluence_prefix', config_options.Type(str, default='')),
+        ('confluence_suffix', config_options.Type(str, default='')),
         ('space_key', config_options.Type(str, required=True)),
         ('parent_page_id', config_options.Type(int, required=True)),
     )
@@ -39,11 +40,12 @@ class ConfluencePublisherPlugin(BasePlugin):
 
     def on_nav(self, nav, config, files):
         prefix = self.config['confluence_prefix']
+        sufix = self.config['confluence_suffix']
         space_key = self.config['space_key']
         parent_page_id = self.config['parent_page_id']
         self.logger.info(
             f"Ensuring pages exist in Confluence with prefix '{prefix}' under parent {parent_page_id} in space: '{space_key}'")
-        self.md_to_page = create_pages(self.confluence, nav.items, prefix, space_key, parent_page_id,
+        self.md_to_page = create_pages(self.confluence, nav.items, prefix, suffix, space_key, parent_page_id,
                                           self.md_to_page)
         self.logger.debug(f"URL to Page ID mapping: {self.md_to_page}")
 


### PR DESCRIPTION
Because it is mostly better to read in confluence names a descriptor of the content instead of the generic prefix, i added this parameter. Everyone can decide for its own. :)