### PR TITLE
Fix issue #16: support API token auth for Confluence

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,11 @@ plugins:
 The plugin requires the following environment variables to be set:
 
 - `CONFLUENCE_URL`: The base URL of your Confluence instance
-- `CONFLUENCE_USERNAME`: Your Confluence username
-- `CONFLUENCE_API_TOKEN`: Your Confluence API token
+- `CONFLUENCE_USERNAME`: Your Confluence username (required with password auth)
+- `CONFLUENCE_PASSWORD`: Your Confluence password (basic auth)
+- `CONFLUENCE_API_TOKEN`: Your Confluence API token (cloud token auth)
+
+Supply either `CONFLUENCE_PASSWORD` with `CONFLUENCE_USERNAME`, or `CONFLUENCE_API_TOKEN` alone.
 
 You can set these in your environment or use a `.env` file.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,10 @@ plugins:
 
 ## Environment Variables
 
-The plugin supports two authentication modes. Use exactly one.
+The plugin supports token auth with fallback to username/password.
+
+If `CONFLUENCE_API_TOKEN` is set, it is used.
+If not set, `CONFLUENCE_USERNAME` + `CONFLUENCE_PASSWORD` must be set.
 
 API token mode:
 

--- a/README.md
+++ b/README.md
@@ -32,15 +32,19 @@ plugins:
 
 ## Environment Variables
 
-The plugin supports token auth with fallback to username/password.
+The plugin resolves credentials in this order:
 
-If `CONFLUENCE_API_TOKEN` is set, it is used.
-If not set, `CONFLUENCE_USERNAME` + `CONFLUENCE_PASSWORD` must be set.
+1. If `CONFLUENCE_API_TOKEN` is set:
+   - For Cloud Confluence (`atlassian.net` / `jira.com` URLs), set `CONFLUENCE_USERNAME`
+     (typically your email) and the token is used as the password.
+   - For non-cloud Confluence, `CONFLUENCE_API_TOKEN` is used as a bearer token.
+2. If no API token is set, use `CONFLUENCE_USERNAME` + `CONFLUENCE_PASSWORD`.
 
 API token mode:
 
 - `CONFLUENCE_URL`: The base URL of your Confluence instance
 - `CONFLUENCE_API_TOKEN`: Your Confluence API token
+- `CONFLUENCE_USERNAME` (required only for Cloud URLs): Your Confluence username/email
 
 Username/password mode:
 

--- a/README.md
+++ b/README.md
@@ -32,14 +32,18 @@ plugins:
 
 ## Environment Variables
 
-The plugin requires the following environment variables to be set:
+The plugin supports two authentication modes. Use exactly one.
+
+API token mode:
 
 - `CONFLUENCE_URL`: The base URL of your Confluence instance
-- `CONFLUENCE_USERNAME`: Your Confluence username (required with password auth)
-- `CONFLUENCE_PASSWORD`: Your Confluence password (basic auth)
-- `CONFLUENCE_API_TOKEN`: Your Confluence API token (cloud token auth)
+- `CONFLUENCE_API_TOKEN`: Your Confluence API token
 
-Supply either `CONFLUENCE_PASSWORD` with `CONFLUENCE_USERNAME`, or `CONFLUENCE_API_TOKEN` alone.
+Username/password mode:
+
+- `CONFLUENCE_URL`: The base URL of your Confluence instance
+- `CONFLUENCE_USERNAME`: Your Confluence username
+- `CONFLUENCE_PASSWORD`: Your Confluence password
 
 You can set these in your environment or use a `.env` file.
 

--- a/example-docs/README.md
+++ b/example-docs/README.md
@@ -22,6 +22,8 @@ To run the example project and test the development version of the plugin:
    # Option 1: API token mode (takes precedence if set)
    CONFLUENCE_URL=<your_confluence_url>
    CONFLUENCE_API_TOKEN=<your_api_token>
+   # For atlassian.net / jira.com URLs, also set CONFLUENCE_USERNAME (email)
+   # CONFLUENCE_USERNAME=<your_username>
 
    # Option 2: username/password mode
    CONFLUENCE_USERNAME=<your_username>

--- a/example-docs/README.md
+++ b/example-docs/README.md
@@ -19,7 +19,7 @@ To run the example project and test the development version of the plugin:
 2. **Set up your Confluence environment:**
    Create a `.env` file in the project root with your Confluence credentials:
    ```
-   # Option 1: API token mode
+   # Option 1: API token mode (takes precedence if set)
    CONFLUENCE_URL=<your_confluence_url>
    CONFLUENCE_API_TOKEN=<your_api_token>
 

--- a/example-docs/README.md
+++ b/example-docs/README.md
@@ -20,8 +20,12 @@ To run the example project and test the development version of the plugin:
    Create a `.env` file in the project root with your Confluence credentials:
    ```
    CONFLUENCE_URL=<your_confluence_url>
+   # Username only required for username/password authentication
    CONFLUENCE_USERNAME=<your_username>
+   # Option 1: token auth (Cloud)
    CONFLUENCE_API_TOKEN=<your_api_token>
+   # Option 2: username + password auth
+   # CONFLUENCE_PASSWORD=<your_password>
    ```
 
 3. **Update `mkdocs.yml`:**

--- a/example-docs/README.md
+++ b/example-docs/README.md
@@ -19,12 +19,12 @@ To run the example project and test the development version of the plugin:
 2. **Set up your Confluence environment:**
    Create a `.env` file in the project root with your Confluence credentials:
    ```
+   # Option 1: API token mode
    CONFLUENCE_URL=<your_confluence_url>
-   # Username only required for username/password authentication
-   CONFLUENCE_USERNAME=<your_username>
-   # Option 1: token auth (Cloud)
    CONFLUENCE_API_TOKEN=<your_api_token>
-   # Option 2: username + password auth
+
+   # Option 2: username/password mode
+   CONFLUENCE_USERNAME=<your_username>
    # CONFLUENCE_PASSWORD=<your_password>
    ```
 

--- a/example-docs/docs/sub-pages/sub-page1.md
+++ b/example-docs/docs/sub-pages/sub-page1.md
@@ -2,7 +2,7 @@
 
 This is the first sub-page.
 
-Here is a link back to the [sub-pages index](../sub-pages/index.md).
+Here is a link back to the [sub-pages index](index.md).
 
 ## Mermaid Diagram
 

--- a/example-docs/docs/sub-pages/sub-page2.md
+++ b/example-docs/docs/sub-pages/sub-page2.md
@@ -2,7 +2,7 @@
 
 This is the second sub-page.
 
-Here is a link to the [main index page](../../index.md).
+Here is a link to the [main index page](../index.md).
 
 ## Jump Section
 

--- a/example-docs/run-example.sh
+++ b/example-docs/run-example.sh
@@ -31,6 +31,13 @@ check_env_var "CONFLUENCE_URL"
 
 if [ -n "${CONFLUENCE_API_TOKEN}" ]; then
   echo "Using API token mode."
+  if [[ "${CONFLUENCE_URL}" == *atlassian.net* || "${CONFLUENCE_URL}" == *jira.com* ]]; then
+    if [ -z "${CONFLUENCE_USERNAME}" ]; then
+      echo "Cloud URL detected. CONFLUENCE_USERNAME is required when using CONFLUENCE_API_TOKEN."
+      exit 1
+    fi
+    echo "Cloud URL detected: using username + API token as password."
+  fi
 elif [ -n "${CONFLUENCE_USERNAME}" ] && [ -n "${CONFLUENCE_PASSWORD}" ]; then
   echo "Using username/password mode."
 elif [ -n "${CONFLUENCE_USERNAME}" ] || [ -n "${CONFLUENCE_PASSWORD}" ]; then

--- a/example-docs/run-example.sh
+++ b/example-docs/run-example.sh
@@ -28,16 +28,25 @@ fi
 
 # Check for required environment variables
 check_env_var "CONFLUENCE_URL"
-if [ -z "${CONFLUENCE_API_TOKEN}" ] && [ -z "${CONFLUENCE_USERNAME}" ]; then
-  echo "Error: Either CONFLUENCE_API_TOKEN or CONFLUENCE_USERNAME must be set."
-  echo "If using basic auth, set both CONFLUENCE_USERNAME and CONFLUENCE_PASSWORD."
-  echo "Please set one of them in your environment or in the ${ENV_FILE} file."
-  exit 1
-fi
 
-if [ -z "${CONFLUENCE_API_TOKEN}" ] && [ -z "${CONFLUENCE_PASSWORD}" ]; then
-  echo "Error: Either CONFLUENCE_API_TOKEN or CONFLUENCE_PASSWORD must be set."
-  echo "Please set one of them in your environment or in the ${ENV_FILE} file."
+if [ -n "${CONFLUENCE_API_TOKEN}" ]; then
+  if [ -n "${CONFLUENCE_USERNAME}" ] || [ -n "${CONFLUENCE_PASSWORD}" ]; then
+    echo "Error: API token mode selected, but username/password are also set."
+    echo "Use only CONFLUENCE_API_TOKEN for token mode."
+    echo "Remove CONFLUENCE_USERNAME and CONFLUENCE_PASSWORD, or use username/password mode instead."
+    exit 1
+  fi
+  echo "Using API token mode."
+elif [ -n "${CONFLUENCE_USERNAME}" ] && [ -n "${CONFLUENCE_PASSWORD}" ]; then
+  echo "Using username/password mode."
+elif [ -n "${CONFLUENCE_USERNAME}" ] || [ -n "${CONFLUENCE_PASSWORD}" ]; then
+  echo "Error: Username/password mode requires both CONFLUENCE_USERNAME and CONFLUENCE_PASSWORD."
+  echo "Please set both values in your environment or in the ${ENV_FILE} file."
+  exit 1
+else
+  echo "Error: No credentials found."
+  echo "Set CONFLUENCE_API_TOKEN for token mode,"
+  echo "or both CONFLUENCE_USERNAME and CONFLUENCE_PASSWORD for username/password mode."
   exit 1
 fi
 check_env_var "CONFLUENCE_SPACE_KEY"

--- a/example-docs/run-example.sh
+++ b/example-docs/run-example.sh
@@ -30,12 +30,6 @@ fi
 check_env_var "CONFLUENCE_URL"
 
 if [ -n "${CONFLUENCE_API_TOKEN}" ]; then
-  if [ -n "${CONFLUENCE_USERNAME}" ] || [ -n "${CONFLUENCE_PASSWORD}" ]; then
-    echo "Error: API token mode selected, but username/password are also set."
-    echo "Use only CONFLUENCE_API_TOKEN for token mode."
-    echo "Remove CONFLUENCE_USERNAME and CONFLUENCE_PASSWORD, or use username/password mode instead."
-    exit 1
-  fi
   echo "Using API token mode."
 elif [ -n "${CONFLUENCE_USERNAME}" ] && [ -n "${CONFLUENCE_PASSWORD}" ]; then
   echo "Using username/password mode."

--- a/example-docs/run-example.sh
+++ b/example-docs/run-example.sh
@@ -28,8 +28,18 @@ fi
 
 # Check for required environment variables
 check_env_var "CONFLUENCE_URL"
-check_env_var "CONFLUENCE_USERNAME"
-check_env_var "CONFLUENCE_API_TOKEN"
+if [ -z "${CONFLUENCE_API_TOKEN}" ] && [ -z "${CONFLUENCE_USERNAME}" ]; then
+  echo "Error: Either CONFLUENCE_API_TOKEN or CONFLUENCE_USERNAME must be set."
+  echo "If using basic auth, set both CONFLUENCE_USERNAME and CONFLUENCE_PASSWORD."
+  echo "Please set one of them in your environment or in the ${ENV_FILE} file."
+  exit 1
+fi
+
+if [ -z "${CONFLUENCE_API_TOKEN}" ] && [ -z "${CONFLUENCE_PASSWORD}" ]; then
+  echo "Error: Either CONFLUENCE_API_TOKEN or CONFLUENCE_PASSWORD must be set."
+  echo "Please set one of them in your environment or in the ${ENV_FILE} file."
+  exit 1
+fi
 check_env_var "CONFLUENCE_SPACE_KEY"
 check_env_var "CONFLUENCE_PARENT_PAGE_ID"
 

--- a/mkdocs_confluence_publisher/plugin.py
+++ b/mkdocs_confluence_publisher/plugin.py
@@ -43,27 +43,18 @@ class ConfluencePublisherPlugin(BasePlugin):
         confluence_password = os.environ.get('CONFLUENCE_PASSWORD')
         confluence_api_token = os.environ.get('CONFLUENCE_API_TOKEN')
 
-        has_token = bool(confluence_api_token)
-        has_username_password = bool(confluence_username and confluence_password)
-        has_username_or_password = bool(confluence_username or confluence_password)
-
-        if has_token and has_username_or_password:
-            self.logger.error(
-                "Both token and username/password credentials are provided. "
-                "Use either API token mode (CONFLUENCE_API_TOKEN) or "
-                "username/password mode (CONFLUENCE_USERNAME and CONFLUENCE_PASSWORD), not both."
-            )
-            self.enabled = False
-            return config
-
-        if has_token:
+        if confluence_api_token:
+            if confluence_username or confluence_password:
+                self.logger.debug(
+                    "CONFLUENCE_API_TOKEN is set. Ignoring CONFLUENCE_USERNAME/CONFLUENCE_PASSWORD."
+                )
             # Atlassian cloud and recent API token flows use bearer token auth.
             self.confluence = Confluence(
                 url=confluence_url,
                 token=confluence_api_token
             )
             self.logger.debug("Initialized Confluence with API token auth")
-        elif has_username_password:
+        elif confluence_username and confluence_password:
             self.confluence = Confluence(
                 url=confluence_url,
                 username=confluence_username,

--- a/mkdocs_confluence_publisher/plugin.py
+++ b/mkdocs_confluence_publisher/plugin.py
@@ -43,17 +43,30 @@ class ConfluencePublisherPlugin(BasePlugin):
         confluence_password = os.environ.get('CONFLUENCE_PASSWORD')
         confluence_api_token = os.environ.get('CONFLUENCE_API_TOKEN')
 
+        is_confluence_cloud = confluence_url and ("atlassian.net" in confluence_url or "jira.com" in confluence_url)
+
         if confluence_api_token:
-            if confluence_username or confluence_password:
-                self.logger.debug(
-                    "CONFLUENCE_API_TOKEN is set. Ignoring CONFLUENCE_USERNAME/CONFLUENCE_PASSWORD."
+            if is_confluence_cloud and confluence_username:
+                # Cloud supports API token via basic auth: username=email and token=password
+                self.confluence = Confluence(
+                    url=confluence_url,
+                    username=confluence_username,
+                    password=confluence_api_token
                 )
-            # Atlassian cloud and recent API token flows use bearer token auth.
-            self.confluence = Confluence(
-                url=confluence_url,
-                token=confluence_api_token
-            )
-            self.logger.debug("Initialized Confluence with API token auth")
+                self.logger.debug("Initialized Confluence with Cloud username/API token basic auth")
+            elif is_confluence_cloud and not confluence_username:
+                self.logger.error(
+                    "Cloud Confluence requires CONFLUENCE_USERNAME when CONFLUENCE_API_TOKEN is set."
+                )
+                self.enabled = False
+                return config
+            else:
+                # Non-cloud: use bearer token session
+                self.confluence = Confluence(
+                    url=confluence_url,
+                    token=confluence_api_token
+                )
+                self.logger.debug("Initialized Confluence with API token auth")
         elif confluence_username and confluence_password:
             self.confluence = Confluence(
                 url=confluence_url,

--- a/mkdocs_confluence_publisher/plugin.py
+++ b/mkdocs_confluence_publisher/plugin.py
@@ -43,23 +43,37 @@ class ConfluencePublisherPlugin(BasePlugin):
         confluence_password = os.environ.get('CONFLUENCE_PASSWORD')
         confluence_api_token = os.environ.get('CONFLUENCE_API_TOKEN')
 
-        if confluence_api_token:
+        has_token = bool(confluence_api_token)
+        has_username_password = bool(confluence_username and confluence_password)
+        has_username_or_password = bool(confluence_username or confluence_password)
+
+        if has_token and has_username_or_password:
+            self.logger.error(
+                "Both token and username/password credentials are provided. "
+                "Use either API token mode (CONFLUENCE_API_TOKEN) or "
+                "username/password mode (CONFLUENCE_USERNAME and CONFLUENCE_PASSWORD), not both."
+            )
+            self.enabled = False
+            return config
+
+        if has_token:
             # Atlassian cloud and recent API token flows use bearer token auth.
             self.confluence = Confluence(
                 url=confluence_url,
                 token=confluence_api_token
             )
-            self.logger.debug("Initialized Confluence with API token")
-        elif confluence_username and confluence_password:
+            self.logger.debug("Initialized Confluence with API token auth")
+        elif has_username_password:
             self.confluence = Confluence(
                 url=confluence_url,
                 username=confluence_username,
                 password=confluence_password
             )
-            self.logger.debug("Initialized Confluence with username/password")
+            self.logger.debug("Initialized Confluence with username/password auth")
         else:
             self.logger.error(
-                "Confluence credentials not configured. Set CONFLUENCE_USERNAME and CONFLUENCE_PASSWORD or CONFLUENCE_API_TOKEN."
+                "Confluence credentials not configured. Set API token mode: CONFLUENCE_API_TOKEN, "
+                "or username/password mode: CONFLUENCE_USERNAME and CONFLUENCE_PASSWORD."
             )
             self.enabled = False
             return config

--- a/mkdocs_confluence_publisher/plugin.py
+++ b/mkdocs_confluence_publisher/plugin.py
@@ -37,11 +37,33 @@ class ConfluencePublisherPlugin(BasePlugin):
 
         self.enabled = True
         self.logger.debug("Initializing Confluence connection")
-        self.confluence = Confluence(
-            url=os.environ.get('CONFLUENCE_URL'),
-            username=os.environ.get('CONFLUENCE_USERNAME'),
-            password=os.environ.get('CONFLUENCE_API_TOKEN')
-        )
+
+        confluence_url = os.environ.get('CONFLUENCE_URL')
+        confluence_username = os.environ.get('CONFLUENCE_USERNAME')
+        confluence_password = os.environ.get('CONFLUENCE_PASSWORD')
+        confluence_api_token = os.environ.get('CONFLUENCE_API_TOKEN')
+
+        if confluence_api_token:
+            # Atlassian cloud and recent API token flows use bearer token auth.
+            self.confluence = Confluence(
+                url=confluence_url,
+                token=confluence_api_token
+            )
+            self.logger.debug("Initialized Confluence with API token")
+        elif confluence_username and confluence_password:
+            self.confluence = Confluence(
+                url=confluence_url,
+                username=confluence_username,
+                password=confluence_password
+            )
+            self.logger.debug("Initialized Confluence with username/password")
+        else:
+            self.logger.error(
+                "Confluence credentials not configured. Set CONFLUENCE_USERNAME and CONFLUENCE_PASSWORD or CONFLUENCE_API_TOKEN."
+            )
+            self.enabled = False
+            return config
+
         self.logger.debug("Confluence connection initialized")
         return config
 

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -24,6 +24,43 @@ class TestConfluencePublisherPluginConfig(unittest.TestCase):
                 token='api-token-123'
             )
 
+    def test_on_config_uses_username_password_when_api_token_and_cloud_url(self):
+        with patch('mkdocs_confluence_publisher.plugin.Confluence') as mock_confluence:
+            plugin = ConfluencePublisherPlugin()
+            with patch.dict(
+                os.environ,
+                {
+                    'CONFLUENCE_URL': 'https://company.atlassian.net',
+                    'CONFLUENCE_API_TOKEN': 'api-token-123',
+                    'CONFLUENCE_USERNAME': 'user@example.com',
+                },
+                clear=True,
+            ):
+                plugin.on_config({})
+
+            mock_confluence.assert_called_once_with(
+                url='https://company.atlassian.net',
+                username='user@example.com',
+                password='api-token-123'
+            )
+            self.assertTrue(plugin.enabled)
+
+    def test_on_config_disables_cloud_api_token_without_username(self):
+        with patch('mkdocs_confluence_publisher.plugin.Confluence') as mock_confluence:
+            plugin = ConfluencePublisherPlugin()
+            with patch.dict(
+                os.environ,
+                {
+                    'CONFLUENCE_URL': 'https://company.atlassian.net',
+                    'CONFLUENCE_API_TOKEN': 'api-token-123',
+                },
+                clear=True,
+            ):
+                plugin.on_config({})
+
+            mock_confluence.assert_not_called()
+            self.assertFalse(plugin.enabled)
+
     def test_on_config_falls_back_to_username_password(self):
         with patch('mkdocs_confluence_publisher.plugin.Confluence') as mock_confluence:
             plugin = ConfluencePublisherPlugin()

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -59,7 +59,7 @@ class TestConfluencePublisherPluginConfig(unittest.TestCase):
             mock_confluence.assert_not_called()
             self.assertFalse(plugin.enabled)
 
-    def test_on_config_disables_when_both_modes_are_set(self):
+    def test_on_config_prefers_api_token_auth_when_both_provided(self):
         with patch('mkdocs_confluence_publisher.plugin.Confluence') as mock_confluence:
             plugin = ConfluencePublisherPlugin()
             with patch.dict(
@@ -74,8 +74,11 @@ class TestConfluencePublisherPluginConfig(unittest.TestCase):
             ):
                 plugin.on_config({})
 
-            mock_confluence.assert_not_called()
-            self.assertFalse(plugin.enabled)
+            mock_confluence.assert_called_once_with(
+                url='https://confluence.example.com',
+                token='api-token-123'
+            )
+            self.assertTrue(plugin.enabled)
 
 
 if __name__ == '__main__':

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -1,0 +1,65 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from mkdocs_confluence_publisher.plugin import ConfluencePublisherPlugin
+
+
+class TestConfluencePublisherPluginConfig(unittest.TestCase):
+    def test_on_config_prefers_api_token_auth(self):
+        with patch('mkdocs_confluence_publisher.plugin.Confluence') as mock_confluence:
+            plugin = ConfluencePublisherPlugin()
+            with patch.dict(
+                os.environ,
+                {
+                    'CONFLUENCE_URL': 'https://confluence.example.com',
+                    'CONFLUENCE_API_TOKEN': 'api-token-123',
+                    'CONFLUENCE_USERNAME': 'ignored@example.com',
+                },
+                clear=True,
+            ):
+                plugin.on_config({})
+
+            mock_confluence.assert_called_once_with(
+                url='https://confluence.example.com',
+                token='api-token-123'
+            )
+
+    def test_on_config_falls_back_to_username_password(self):
+        with patch('mkdocs_confluence_publisher.plugin.Confluence') as mock_confluence:
+            plugin = ConfluencePublisherPlugin()
+            with patch.dict(
+                os.environ,
+                {
+                    'CONFLUENCE_URL': 'https://confluence.example.com',
+                    'CONFLUENCE_USERNAME': 'user@example.com',
+                    'CONFLUENCE_PASSWORD': 'super-secret',
+                },
+                clear=True,
+            ):
+                plugin.on_config({})
+
+            mock_confluence.assert_called_once_with(
+                url='https://confluence.example.com',
+                username='user@example.com',
+                password='super-secret'
+            )
+
+    def test_on_config_disables_when_credentials_missing(self):
+        with patch('mkdocs_confluence_publisher.plugin.Confluence') as mock_confluence:
+            plugin = ConfluencePublisherPlugin()
+            with patch.dict(
+                os.environ,
+                {
+                    'CONFLUENCE_URL': 'https://confluence.example.com',
+                },
+                clear=True,
+            ):
+                plugin.on_config({})
+
+            mock_confluence.assert_not_called()
+            self.assertFalse(plugin.enabled)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_plugin.py
+++ b/tests/unit/test_plugin.py
@@ -14,7 +14,6 @@ class TestConfluencePublisherPluginConfig(unittest.TestCase):
                 {
                     'CONFLUENCE_URL': 'https://confluence.example.com',
                     'CONFLUENCE_API_TOKEN': 'api-token-123',
-                    'CONFLUENCE_USERNAME': 'ignored@example.com',
                 },
                 clear=True,
             ):
@@ -52,6 +51,24 @@ class TestConfluencePublisherPluginConfig(unittest.TestCase):
                 os.environ,
                 {
                     'CONFLUENCE_URL': 'https://confluence.example.com',
+                },
+                clear=True,
+            ):
+                plugin.on_config({})
+
+            mock_confluence.assert_not_called()
+            self.assertFalse(plugin.enabled)
+
+    def test_on_config_disables_when_both_modes_are_set(self):
+        with patch('mkdocs_confluence_publisher.plugin.Confluence') as mock_confluence:
+            plugin = ConfluencePublisherPlugin()
+            with patch.dict(
+                os.environ,
+                {
+                    'CONFLUENCE_URL': 'https://confluence.example.com',
+                    'CONFLUENCE_API_TOKEN': 'api-token-123',
+                    'CONFLUENCE_USERNAME': 'user@example.com',
+                    'CONFLUENCE_PASSWORD': 'super-secret',
                 },
                 clear=True,
             ):


### PR DESCRIPTION
Fix authentication so CONFLUENCE_API_TOKEN uses token session (as required), with fallback to username/password via CONFLUENCE_USERNAME + CONFLUENCE_PASSWORD. Includes docs/examples updates and tests.

Tests run:
- PYTHONPATH=/tmp/mkdocs_test_stubs:. pytest -q tests/unit (7 passed)