### PR TITLE
Pin compatible Markdown renderer dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,8 @@
 mkdocs>=1.0
 atlassian-python-api>=3.14.0
-mistune
-md2cf
+mistune==0.8.4
+md2cf==1.0.2
+PyYAML>=6.0.3
 python-dotenv
 pytest
 pytest-mock

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,9 @@ setup(
     install_requires=[
         'mkdocs>=1.0',
         'atlassian-python-api>=3.14.0',
-        'mistune',
-        'md2cf',
+        'mistune==0.8.4',
+        'md2cf==1.0.2',
+        'PyYAML>=6.0.3',
         'python-dotenv',
         'mermaid-py'
     ],


### PR DESCRIPTION
## Problem

The unconstrained `mistune` and `md2cf` dependencies can resolve to incompatible combinations:

- Mistune 2/3 no longer provides the legacy `Renderer` API required by `md2cf.confluence_renderer.ConfluenceRenderer`.
- Some md2cf releases pin PyYAML versions that cannot be installed on newer Python versions.

This can prevent the plugin from importing or installing successfully.

## Change

- Pin `mistune==0.8.4`
- Pin `md2cf==1.0.2`
- Require `PyYAML>=6.0.3`
- Apply the constraints consistently in `setup.py` and `requirements.txt`

The older md2cf version is deliberate: it provides the renderer API used by this plugin without hard-pinning an obsolete PyYAML release.

## Verification

Tested in a clean Python 3.14 environment:

- Package installation succeeds
- Dependency compatibility check passes
- Markdown-to-Confluence renderer smoke test passes
- All 11 existing tests pass